### PR TITLE
Fixes #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ app.listen(3000);
 * **debug**: If evalutes to true then a new line will be sent after each chunk of data written to the response so that you can see the data coming in if testing with curl. Default is false
 
 ## Testing
+
 Run:
-```cd test; node test.js```
+```cd test; npm install; node test.js```
 Then to see the data throttled flow in:
 ```
 curl http://localhost:3000/string
 curl http://localhost:3000/buffer
-curl http://localhost:3000/stream 
+curl http://localhost:3000/stream
 ```
-

--- a/README.md
+++ b/README.md
@@ -41,4 +41,5 @@ Then to see the data throttled flow in:
 curl http://localhost:3000/string
 curl http://localhost:3000/buffer
 curl http://localhost:3000/stream
+curl http://localhost:3000/test/package.json
 ```

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 # koa-throttle
-Using the Koa framework, throttle the body of a response by specifying the rate or delay and chunk size. 
+
+Using the Koa framework, throttle the body of a response by specifying the rate or delay and chunk size.
 
 ## Install
 
-
+```bash
+$ npm install koa-throttle --save
+```
 
 ## Usage
 
@@ -18,7 +21,7 @@ app
   .use(function *test(next){
     this.body = 'This is a big test string that will be throttled';
   });
-  
+
 
 app.listen(3000);
 ```

--- a/test/package.json
+++ b/test/package.json
@@ -7,6 +7,7 @@
   "license": "MIT",
   "dependencies": {
     "co": "^4.6.0",
+    "koa": "^1.2.4",
     "koa-route": "^2.4.2"
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "co": "^4.6.0",
     "koa": "^1.2.4",
-    "koa-route": "^2.4.2"
+    "koa-route": "^2.4.2",
+    "koa-static": "^2.0.0"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,7 @@
-var Readable = require('stream').Readable
+var Readable = require('stream').Readable;
 var koa = require('koa');
 var route = require('koa-route');
+var serve = require('koa-static');
 var Throttler = require('../index');
 
 var app = koa();
@@ -20,7 +21,7 @@ app
     this.body = r;
     r.push(" BEFORE ");
     r.push(null);
-  }));
-  
+  }))
+  .use(route.get(/\/test\//, serve('.')));
 
 app.listen(3000);


### PR DESCRIPTION
This PR lets koa-throttle work with koa-static by replacing `that.body` with a new stream _before_ any modifications to the response are performed.

`streamToString()` is no longer called for Streams and Buffers as it interferes with sending binary content, e.g. images.

Minor fixes are also included.  README updates and the `package.json` of the test was missing the `koa` dependency.
